### PR TITLE
Fix empty webhook subscription query

### DIFF
--- a/pages/api/webhooks/customer-created.ts
+++ b/pages/api/webhooks/customer-created.ts
@@ -4,6 +4,7 @@ import { withSentry } from "@sentry/nextjs";
 import type { Handler } from "retes";
 import { toNextHandler } from "retes/adapter";
 import { Response } from "retes/response";
+import { gql } from "urql";
 
 import Klaviyo from "../../../lib/klaviyo";
 import { getValue } from "../../../lib/metadata";
@@ -14,7 +15,13 @@ export const customerCreatedWebhook = new SaleorAsyncWebhook<unknown>({
   webhookPath: "api/webhooks/customer-created",
   asyncEvent: "CUSTOMER_CREATED",
   apl: saleorApp.apl,
-  query: "{}",
+  subscriptionQueryAst: gql`
+    subscription {
+      event {
+        version
+      }
+    }
+  `,
 });
 
 const handler: Handler = async (request) => {

--- a/pages/api/webhooks/fulfillment-created.ts
+++ b/pages/api/webhooks/fulfillment-created.ts
@@ -4,6 +4,7 @@ import { withSentry } from "@sentry/nextjs";
 import type { Handler } from "retes";
 import { toNextHandler } from "retes/adapter";
 import { Response } from "retes/response";
+import { gql } from "urql";
 
 import Klaviyo from "../../../lib/klaviyo";
 import { getValue } from "../../../lib/metadata";
@@ -14,7 +15,13 @@ export const fulfillmentCreatedWebhook = new SaleorAsyncWebhook<unknown>({
   webhookPath: "api/webhooks/fulfillment-created",
   asyncEvent: "FULFILLMENT_CREATED",
   apl: saleorApp.apl,
-  query: "{}",
+  subscriptionQueryAst: gql`
+    subscription {
+      event {
+        version
+      }
+    }
+  `,
 });
 
 const handler: Handler = async (request) => {

--- a/pages/api/webhooks/order-created.ts
+++ b/pages/api/webhooks/order-created.ts
@@ -4,6 +4,7 @@ import { withSentry } from "@sentry/nextjs";
 import type { Handler } from "retes";
 import { toNextHandler } from "retes/adapter";
 import { Response } from "retes/response";
+import { gql } from "urql";
 
 import Klaviyo from "../../../lib/klaviyo";
 import { getValue } from "../../../lib/metadata";
@@ -14,7 +15,13 @@ export const orderCreatedWebhook = new SaleorAsyncWebhook<unknown>({
   webhookPath: "api/webhooks/order-created",
   asyncEvent: "ORDER_CREATED",
   apl: saleorApp.apl,
-  query: "{}",
+  subscriptionQueryAst: gql`
+    subscription {
+      event {
+        version
+      }
+    }
+  `,
 });
 
 const handler: Handler = async (request) => {

--- a/pages/api/webhooks/order-fully-paid.ts
+++ b/pages/api/webhooks/order-fully-paid.ts
@@ -4,6 +4,7 @@ import { withSentry } from "@sentry/nextjs";
 import type { Handler } from "retes";
 import { toNextHandler } from "retes/adapter";
 import { Response } from "retes/response";
+import { gql } from "urql";
 
 import Klaviyo from "../../../lib/klaviyo";
 import { getValue } from "../../../lib/metadata";
@@ -14,7 +15,13 @@ export const orderFullyPaidWebhook = new SaleorAsyncWebhook<unknown>({
   webhookPath: "api/webhooks/order-fully-paid",
   asyncEvent: "ORDER_FULLY_PAID",
   apl: saleorApp.apl,
-  query: "{}",
+  subscriptionQueryAst: gql`
+    subscription {
+      event {
+        version
+      }
+    }
+  `,
 });
 
 const handler: Handler = async (request) => {


### PR DESCRIPTION
Fixes `query: {}` in webhook, added basic boilerplate for proper syntax. Tested and installs properly